### PR TITLE
RED-546 Optimized used topic check

### DIFF
--- a/src/database/models/topic-assessment-info.ts
+++ b/src/database/models/topic-assessment-info.ts
@@ -1,5 +1,5 @@
 import * as _ from 'lodash';
-import { Model, DataTypes } from 'sequelize';
+import { Model, DataTypes, HasManyGetAssociationsMixin } from 'sequelize';
 import appSequelize from '../app-sequelize';
 
 interface TopicAssessmentInfoOverridesInterface {
@@ -40,6 +40,8 @@ export default class TopicAssessmentInfo extends Model implements TopicAssessmen
 
     public readonly studentTopicAssessmentOverride?: StudentTopicAssessmentOverride[];
     public readonly studentTopicAssessmentInfo?: StudentTopicAssessmentInfo[];
+
+    public readonly getStudentTopicAssessmentInfo!: HasManyGetAssociationsMixin<StudentTopicAssessmentInfo>;
 
     // timestamps!
     public readonly createdAt!: Date;

--- a/src/database/models/topic-type.ts
+++ b/src/database/models/topic-type.ts
@@ -1,6 +1,11 @@
 import { Model, DataTypes } from 'sequelize';
 import appSequelize from '../app-sequelize';
 
+export enum TopicTypeLookup {
+    HOMEWORK = 1,
+    EXAM = 2,
+}
+
 export default class TopicType extends Model {
     public id!: number; // Note that the `null assertion` `!` is required in strict mode.
     public name!: string;

--- a/src/features/courses/course-repository.ts
+++ b/src/features/courses/course-repository.ts
@@ -229,36 +229,7 @@ class CourseRepository {
     /* ************************* ************************* */
     async getCourseTopic(options: GetCourseTopicRepositoryOptions): Promise<CourseTopicContent> {
         const include: sequelize.IncludeOptions[] = [];
-        const assessmentInclude: sequelize.IncludeOptions[] = [];
 
-        if (options.checkUsed) {
-            include.push({
-                model: CourseWWTopicQuestion,
-                as: 'questions',
-                required: false,
-                where: {
-                    active: true,
-                },
-                include: [{
-                    model: StudentWorkbook,
-                    as: 'workbooks',
-                    required: false,
-                    where: {
-                        active: true,
-                    },
-                    limit: 1
-                }]
-            });
-            assessmentInclude.push({
-                model: StudentTopicAssessmentInfo,
-                as: 'studentTopicAssessmentInfo',
-                required: false,
-                where: {
-                    active: true,
-                    [`$${CourseTopicContent.name}.${CourseTopicContent.rawAttributes.topicTypeId.field}$`]: 2,
-                },
-            });
-        }
         include.push({
             model: TopicAssessmentInfo,
             as: 'topicAssessmentInfo',
@@ -266,7 +237,6 @@ class CourseRepository {
                 active: true
             },
             required: false,
-            include: assessmentInclude,
         });
 
         const result = await CourseTopicContent.findOne({

--- a/src/features/courses/course-types.ts
+++ b/src/features/courses/course-types.ts
@@ -81,8 +81,6 @@ export interface GetCourseTopicRepositoryOptions {
     id: number;
     // For overrides
     userId?: number;
-    // to check if the topic has been 'used'
-    checkUsed?: boolean;
 }
 
 export interface GetTopicAssessmentInfoByTopicIdOptions {


### PR DESCRIPTION
Instead of fetching all the information up from only fetch the
information as it is needed (did this by using multiple queries and
adding a utility function)

If it is not an exam don't check if there are active exams (should be
fastest check and is required if a student hasn't submitted their exam)
Always check if there are any workbooks for a student (could optmize by
skipping this on exams)

Results:
Originally before adding the limit 1 the topic would take up until the
server would crash based on the number of workbooks to update

After adding the limit we saw updates taking between 1 and 3 seconds

With these  changes if the topic type does not change we are seeing a
quarter second update time, if the topic type does change it is about 1
second